### PR TITLE
Updated to libvirt-python-2.1.0 per github issue

### DIFF
--- a/virt-manager.rb
+++ b/virt-manager.rb
@@ -23,8 +23,8 @@ class VirtManager < Formula
   # TODO: audio
 
   resource "libvirt-python" do
-    url "https://libvirt.org/sources/python/libvirt-python-1.3.5.tar.gz"
-    sha256 "a0508a57637fd18a3584fb9d2322fb172f65708c9db16e0438a70eb0f36fa5c2"
+    url "https://libvirt.org/sources/python/libvirt-python-2.1.0.tar.gz"
+    sha256 "74887fa1be60db2701e726da7e01e3bf18ecd3b8d1cfdf2f1f7480e1a1edbacb"
   end
 
   resource "requests" do


### PR DESCRIPTION
As per Marzelpan's comment at https://github.com/jeffreywildman/homebrew-virt-manager/issues/50#issuecomment-238082492, this fixes the installation on OS X El Capitan.

Other things people probably need to know:
* **El Capitan specific** `brew link libvirt usbredir` didn't work, because /usr/local/sbin wasn't writable? Homebrew has the tip:
```If things fail with permissions errors, check the permissions in /usr/local. If you’re unsure what to do, you can sudo chown -R $(whoami) /usr/local.```
This worked for me.

* Can't connect to the remote system? Probs the default socket virt-manager is trying to use ain't right. Try `virt-manager -c "qemu+ssh://root@hostname_or_ip/system?socket=/var/run/libvirt/libvirt-sock"`. The `?socket=...` bit is what you can't do in the GUI.

* Make sure you can actually SSH into root on your target system. You could SSH in as a user, but your user session is probably not where your virtual machines actually are. Consider changing `PermitRootLogin` in your remote system's sshd config to `PermitRootLogin prohibit-password` and allowing SSH key access by appending your local system's id_rsa.pub contents into the `root@your_remote_system:.ssh/authorized_keys` file. Create it if it doesn't exist.

Anyway, this now all works for me... OS X 10.11.5.