### PR TITLE
enable audio/video streaming; overhaul build

### DIFF
--- a/spice-gtk.rb
+++ b/spice-gtk.rb
@@ -1,8 +1,8 @@
 class SpiceGtk < Formula
   desc "GTK client/libraries for SPICE"
   homepage "https://www.spice-space.org"
-  url "https://www.spice-space.org/download/gtk/spice-gtk-0.31.tar.bz2"
-  sha256 "c72b4d202b1c0b71d6e24ce5caf914d6dddbcf4010d10db9c2d8e73af728c1ca"
+  url "https://www.spice-space.org/download/gtk/spice-gtk-0.34.tar.bz2"
+  sha256 "e9720e01165f8451c9f3f58ad50e3afb990993b81cc2db86b3661b7ac5b976ee"
 
   depends_on "gobject-introspection" => :build
   depends_on "intltool" => :build
@@ -16,22 +16,97 @@ class SpiceGtk < Formula
   depends_on "glib"
   depends_on "gtk+3"
   depends_on "jpeg"
+  depends_on "lz4"
   depends_on "openssl"
   depends_on "pango"
   depends_on "pixman"
   depends_on "spice-protocol"
   depends_on "usbredir"
-  # TODO: audio
+
+  # for --enable-gst(audio|video)
+  depends_on "gstreamer"
+  depends_on "gst-libav"
+  depends_on "gst-plugins-base"
+  depends_on "gst-plugins-good"
+  depends_on "gst-plugins-bad"
+  depends_on "gst-plugins-ugly"
+
+  # need autogen to regen after patching the build
+  depends_on "autogen"
+  depends_on "automake"
+  depends_on "autoconf"
+
+  # compile vncdisplaykeymap.c as objc to fix include issue
+  patch :DATA
 
   def install
+    ENV['CFLAGS'] = "-Wno-cast-align -Wno-error"
+    ENV['XML_CATALOG_FILES'] = "/usr/local/etc/xml/catalog"
+
+    mv "src/vncdisplaykeymap.c", "src/vncdisplaykeymap.m"
+
+    system "autoreconf", "-v", "--force", "--install"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--with-gtk=3.0",
                           "--enable-introspection",
                           "--enable-vala",
-                          "--with-audio=no",
+                          "--enable-gstvideo",
+                          "--enable-gstaudio",
+                          "--enable-gstreamer=1.0",
+                          "--with-lz4",
                           "--with-coroutine=gthread",
                           "--prefix=#{prefix}"
     system "make", "install"
   end
 end
+__END__
+diff --git a/configure.ac b/configure.ac
+index f915d81..10ef73d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -25,6 +25,7 @@ AC_SUBST(SPICE_GTK_LOCALEDIR)
+ 
+ GTK_DOC_CHECK([1.14],[--flavour no-tmpl])
+ 
++AC_PROG_OBJC
+ AC_PROG_CC
+ AC_PROG_CC_C99
+ if test "x$ac_cv_prog_cc_c99" = xno; then
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 5430d84..dad3fa5 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -125,7 +125,7 @@ SPICE_GTK_SOURCES_COMMON =		\
+ 	spice-widget.c			\
+ 	spice-widget-priv.h		\
+ 	spice-file-transfer-task.h \
+-	vncdisplaykeymap.c		\
++	vncdisplaykeymap.m		\
+ 	vncdisplaykeymap.h		\
+ 	spice-grabsequence.c		\
+ 	spice-grabsequence.h		\
+@@ -481,7 +481,7 @@ spice-widget-enums.h: spice-widget.h
+ 		$< >  $@
+ 
+ 
+-vncdisplaykeymap.c: $(KEYMAPS)
++vncdisplaykeymap.m: $(KEYMAPS)
+ $(KEYMAPS): $(srcdir)/$(KEYMAP_GEN) $(srcdir)/$(KEYMAP_CSV)
+ 
+ vncdisplaykeymap_xorgevdev2xtkbd.c:
+diff --git a/spice-common/m4/spice-deps.m4 b/spice-common/m4/spice-deps.m4
+index 68e3091..2e4c305 100644
+--- a/spice-common/m4/spice-deps.m4
++++ b/spice-common/m4/spice-deps.m4
+@@ -1,10 +1,3 @@
+-# For autoconf < 2.63
+-m4_ifndef([AS_VAR_APPEND],
+-          AC_DEFUN([AS_VAR_APPEND], $1=$$1$2))
+-m4_ifndef([AS_VAR_COPY],
+-          [m4_define([AS_VAR_COPY],
+-          [AS_LITERAL_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])])
+-
+ 
+ # SPICE_WARNING(warning)
+ # SPICE_PRINT_MESSAGES

--- a/spice-protocol.rb
+++ b/spice-protocol.rb
@@ -1,13 +1,11 @@
 class SpiceProtocol < Formula
   desc "Headers for SPICE protocol"
   homepage "https://www.spice-space.org/"
-  url "https://www.spice-space.org/download/releases/spice-protocol-0.12.12.tar.bz2"
-  sha256 "17abdc2743b5d44b0f4423b61c44aafe9f2078c27218aeea78c2d02a5c409d03"
+  url "https://www.spice-space.org/download/releases/spice-protocol-0.12.13.tar.bz2"
+  sha256 "89ee11b202d2268e061788e6ace114e1ff18c7620ae64d1ca3aba252ee7c9933"
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
+    system "./configure", "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/usbredir.rb
+++ b/usbredir.rb
@@ -10,8 +10,7 @@ class Usbredir < Formula
   depends_on "libusb"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
+    system "./configure", "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/virt-manager.rb
+++ b/virt-manager.rb
@@ -19,6 +19,7 @@ class VirtManager < Formula
   depends_on "pygobject3"
   depends_on "spice-gtk"
   depends_on "vte3"
+  depends_on :python
 
   resource "libvirt-python" do
     url "https://libvirt.org/sources/python/libvirt-python-3.7.0.tar.gz"

--- a/virt-viewer.rb
+++ b/virt-viewer.rb
@@ -1,8 +1,8 @@
 class VirtViewer < Formula
   desc "App for virtualized guest interaction"
   homepage "https://virt-manager.org/"
-  url "https://virt-manager.org/download/sources/virt-viewer/virt-viewer-4.0.tar.gz"
-  sha256 "1c427b0ea104539342519334735e6f667d5784c42a5aafc253b580875d88fa1f"
+  url "https://virt-manager.org/download/sources/virt-viewer/virt-viewer-6.0.tar.gz"
+  sha256 "9037bd7773da4dae761871ec1ab646cfefb4d7e48b1504dddf315a548ccb18b2"
 
   depends_on "intltool" => :build
   depends_on "libtool" => :build
@@ -16,13 +16,12 @@ class VirtViewer < Formula
   depends_on "shared-mime-info"
   depends_on "spice-gtk"
   depends_on "spice-protocol"
-  depends_on :x11
-  # TODO: audio
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
+    system "./configure", "--disable-silent-rules",
                           "--disable-update-mimedb",
+                          "--with-gtk-vnc",
+                          "--with-spice-gtk",
                           "--with-gtk=3.0",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
This patchset updates to spice-gtk 0.34 as well as the latest versions of spice-protocol, virt-manager, and virt-viewer, updates all virt-manager python packages, enables audio/video streaming, patches virt-manager to default to `--no-fork` enabled, and fixes all homebrew/install problems I encountered. It will install and run out of the box on a fresh instance of macOS 10.12.6 Sierra just with `brew install virt-manager; ./virt-manager` and no python path changes required.

It will fix most or all of the following build/crash-related bugs, barring any local user python/compiler issues: #82, #81, #80, #79, #77, #76, #74, #72, #71, #68, #62, #58, #57, #56, #52, #49, #48, #45, #44, #30

It definitely fixes #78 (silently quits at launch) and fixes #5 (support for audio).

----

Furthermore, is there any reason this formula set hasn't been pushed to upstream Homebrew? It should qualify, and `libvirt` is already there. The main changes I'd seek are patching `libvirt` so `qemu+ssh://host/system` will try both the linux and osx socket paths, making `askpass` work, and making sure we use libjpeg-turbo.

----

I'm also willing to share my spice-server and qemu build/config instructions for anyone interested in having working video streaming.