### PR TITLE
Update libvirt-python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If `virt-manager` or its dependencies have been upgraded recently (`brew upgrade
 
 #### Why am I getting the error "No GSettings schemas are installed on the system"?
 
-You must make sure that  ``/usr/local/share`` is not missing from XDG_DATA_DIRS. If it is, add it to XDG_DATA_DIRS. You can make sure by running ``echo $XDG_DATA_DIRS`` .
+You must make sure that  ``/usr/local/share`` is not missing from XDG_DATA_DIRS. If it is, add it to XDG_DATA_DIRS. You can make sure by running ``echo $XDG_DATA_DIRS`` (better in a new bash, zsh etc. session since if you set that environment variable temporarily it would only fix the issue for that shell session). 
 
 [homebrew]: http://brew.sh/
 [virt-manager]: https://virt-manager.org/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ I've not yet tested `virt-manager` against any local URIs/hypervisors. If you ge
 
 If `virt-manager` or its dependencies have been upgraded recently (`brew upgrade`), it's possible that a reinstall may fix the issue (see [#39](https://github.com/jeffreywildman/homebrew-virt-manager/issues/39)).
 
+
+#### Why am I getting the error "No GSettings schemas are installed on the system"?
+
+You must make sure that  ``/usr/local/share`` is not missing from XDG_DATA_DIRS. If it is, add it to XDG_DATA_DIRS. You can make sure by running ``echo $XDG_DATA_DIRS`` .
+
 [homebrew]: http://brew.sh/
 [virt-manager]: https://virt-manager.org/
 [virt-viewer]: https://virt-manager.org/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A set of [homebrew][homebrew] formulae to install [`virt-manager`][virt-manager]
 
 ## Usage
 
-    brew tap jeffreywildman/homebrew-virt-manager
+    brew tap Krish-sysadmin/homebrew-virt-manager
     brew install virt-manager virt-viewer
     virt-manager -c test:///default
 

--- a/virt-manager.rb
+++ b/virt-manager.rb
@@ -27,8 +27,8 @@ class VirtManager < Formula
   depends_on "vte3"
 
   resource "libvirt-python" do
-    url "https://libvirt.org/sources/python/libvirt-python-7.8.0.tar.gz"
-    sha256 "9d07416d66805bf1a17f34491b3ced2ac6c42b6a012ddf9177e0e3ae1b103fd5"
+    url "https://libvirt.org/sources/python/libvirt-python-8.1.0.tar.gz"
+    sha256 "a21ecfab6d29ac1bdd1bfd4aa3ef58447f9f70919aefecd03774613f65914e43"
   end
 
   resource "idna" do

--- a/virt-manager.rb
+++ b/virt-manager.rb
@@ -27,8 +27,8 @@ class VirtManager < Formula
   depends_on "vte3"
 
   resource "libvirt-python" do
-    url "https://libvirt.org/sources/python/libvirt-python-6.10.0.tar.gz"
-    sha256 "47a8e90d9f49bc0296d2817f6009e18dbb69844ce10b81c2a2672bccd6f49fd5"
+    url "https://libvirt.org/sources/python/libvirt-python-7.6.0.tar.gz"
+    sha256 "d8f9d4efdc79ad6b44bc43e49d6fa56d119895ba6c0bb000c6514ce84f19a13e"
   end
 
   resource "idna" do

--- a/virt-manager.rb
+++ b/virt-manager.rb
@@ -27,8 +27,8 @@ class VirtManager < Formula
   depends_on "vte3"
 
   resource "libvirt-python" do
-    url "https://libvirt.org/sources/python/libvirt-python-7.6.0.tar.gz"
-    sha256 "d8f9d4efdc79ad6b44bc43e49d6fa56d119895ba6c0bb000c6514ce84f19a13e"
+    url "https://libvirt.org/sources/python/libvirt-python-7.8.0.tar.gz"
+    sha256 "9d07416d66805bf1a17f34491b3ced2ac6c42b6a012ddf9177e0e3ae1b103fd5"
   end
 
   resource "idna" do

--- a/virt-viewer.rb
+++ b/virt-viewer.rb
@@ -1,7 +1,7 @@
 class VirtViewer < Formula
   desc "App for virtualized guest interaction"
   homepage "https://virt-manager.org/"
-  url "https://virt-manager.org/download/sources/virt-viewer/virt-viewer-8.0.tar.gz"
+  url "https://releases.pagure.org/virt-viewer/virt-viewer-8.0.tar.gz"
   sha256 "dcf358ed5d7a4900215133135a6492c04311d84332816d930df9a89d6195b6ed"
 
   depends_on "intltool" => :build
@@ -22,6 +22,7 @@ class VirtViewer < Formula
   depends_on "shared-mime-info"
   depends_on "spice-gtk"
   depends_on "spice-protocol"
+  depends_on "gobject-introspection"
 
   def install
     args = %W[


### PR DESCRIPTION
When attempting to install virt-manager and virt-viewer there is an issue which a lot of users seem to be facing. I found a fix for this - just upgrading the libvirt-python version in virt-manager.rb (post installation is  /usr/local/Homebrew/Library/Taps/jeffreywildman/homebrew-virt-manager/virt-manager.rb) and changing the SHA256 or there will be a mismatch. This fixes this issue. Furthermore, if post installation a user runs ``` virt-manager -c "qemu:///session" --no-fork ``` and gets the error

``(virt-manager:14339): GLib-GIO-ERROR **:: No GSettings schemas are installed on the system``

they must make sure that  ``/usr/local/share`` is not missing from XDG_DATA_DIRS. This has been added to the README's FAQs too.


```brew install virt-manager virt-viewer                                                                                                                
==> Installing virt-manager from jeffreywildman/virt-manager
==> Downloading https://libvirt.org/sources/python/libvirt-python-6.9.0.tar.gz
Already downloaded: /Users/krishjain/Library/Caches/Homebrew/downloads/dd261826a88e2e0c375cc7929b6ea8ae107d68514bd438ae36ffc766ebdd3aeb--libvirt-python-6.9.0.tar.gz
==> Downloading https://pypi.io/packages/source/i/idna/idna-2.8.tar.gz
Already downloaded: /Users/krishjain/Library/Caches/Homebrew/downloads/89cd3c9503f30cf4794067fbb3bb85881a04d4a79002cd52dd006617f4dee6d5--idna-2.8.tar.gz
==> Downloading https://pypi.io/packages/source/c/certifi/certifi-2019.11.28.tar.gz
Already downloaded: /Users/krishjain/Library/Caches/Homebrew/downloads/d305888203f80870f04cbff5b615679be127a718ffeec3b3ce5db16bdc4abfa2--certifi-2019.11.28.tar.gz
==> Downloading https://pypi.io/packages/source/c/chardet/chardet-3.0.4.tar.gz
Already downloaded: /Users/krishjain/Library/Caches/Homebrew/downloads/0b520e43abac95fdb4182899f49c1c7ced69c67c4bc132b3801691b993eb33f9--chardet-3.0.4.tar.gz
==> Downloading https://pypi.io/packages/source/u/urllib3/urllib3-1.25.7.tar.gz
Already downloaded: /Users/krishjain/Library/Caches/Homebrew/downloads/04dc027e49125d42a130fd408cde60c9d9a87ce021683a3e49bf067a62316261--urllib3-1.25.7.tar.gz
==> Downloading https://pypi.io/packages/source/r/requests/requests-2.22.0.tar.gz
Already downloaded: /Users/krishjain/Library/Caches/Homebrew/downloads/4253f7dff3c4f4a5a7fe142af689d95ed2e77979f696451a78d96412e90b0f94--requests-2.22.0.tar.gz
==> Downloading https://virt-manager.org/download/sources/virt-manager/virt-manager-2.2.1.tar.gz
Already downloaded: /Users/krishjain/Library/Caches/Homebrew/downloads/77e22463a35b2e2bde8d02253c10129aabb1e5dfbfe2e6f33ef87bd35955dcf2--virt-manager-2.2.1.tar.gz
==> Patching
==> python3 -m venv --system-site-packages /usr/local/Cellar/virt-manager/2.2.1_3/libexec
==> /usr/local/Cellar/virt-manager/2.2.1_3/libexec/bin/pip install -v --no-deps --no-binary :a
Last 15 lines from /Users/krishjain/Library/Logs/Homebrew/virt-manager/02.pip:
  Skipping link: yanked for reason: See https://github.com/pypa/pip/issues/8711: https://files.pythonhosted.org/packages/03/0f/b125bfdd145c1d018d75ce87603e7e9ff2416e742c71b5ac7deba13ca699/pip-21.2-py3-none-any.whl#sha256=71f447dff669d8e2f72b880e3d7ddea2c85cfeba0d14f3307f66fc40ff755176 (from https://pypi.org/simple/pip/) (requires-python:>=3.6)
  Skipping link: yanked for reason: See https://github.com/pypa/pip/issues/8711: https://files.pythonhosted.org/packages/9f/74/0e4d75529e8bf6e594d532a28308a5e369c3f7105e1fec2ff0bf86d478b0/pip-21.2.tar.gz#sha256=9254a86b6ff4409f9a6077a93f9b6d27f5d81192a94b8fc94d55ffb763a72c8b (from https://pypi.org/simple/pip/) (requires-python:>=3.6)
  Found link https://files.pythonhosted.org/packages/7c/02/9ab8b431aca1b46fcc1ac830a5870a28a12ba1abfa681904b1d2da876a86/pip-21.2.1-py3-none-any.whl#sha256=da0ac9d9032d1d7bac69e9e301778f77b8b6626b85203f99edd2b545434d90a7 (from https://pypi.org/simple/pip/) (requires-python:>=3.6), version: 21.2.1
  Found link https://files.pythonhosted.org/packages/f7/ce/e359cf283c0c0f2e0af7df8f16c8d79047aa1887a00a5b39b27d8afc49e2/pip-21.2.1.tar.gz#sha256=303a82aaa24cdc01f7ebbd1afc7d1b871a4aa0a88bb5b
  1 class VirtManager < Formula
edef1fa86a3ee44ca0a (from https://pypi.org/simple/pip/) (requires-python:>=3.6), version: 21.2.1
  Found link https://files.pythonhosted.org/packages/8a/d7/f505e91e2cdea53cfcf51f4ac478a8cd64fb0bc1042629cedde20d9a6a9b/pip-21.2.2-py3-none-any.whl#sha256=b02a9d345f913e03fde2ed41896687cc1a2053c6adbe142ec03cff6b0827233d (from https://pypi.org/simple/pip/) (requires-python:>=3.6), version: 21.2.2
  Found link https://files.pythonhosted.org/packages/83/37/3f344e392de7792748ee32e05d7dd6f867eb2166c21c8711280fb30e2128/pip-21.2.2.tar.gz#sha256=38e9250dfb0d7fa842492bede9259d4b3289a936ce454f7c58f059f28a94c01d (from https://pypi.org/simple/pip/) (requires-python:>=3.6), version: 21.2.2
  Found link https://files.pythonhosted.org/packages/ca/bf/4133a0e05eac641ec270bbcef30512b5ad307d7838adb994acd652cc30e3/pip-21.2.3-py3-none-any.whl#sha256=895df6014c2f02f9d278a8ad6e31cdfd312952b4a93c3068d0556964f4490057 (from https://pypi.org/simple/pip/) (requires-python:>=3.6), version: 21.2.3
  Found link https://files.pythonhosted.org/packages/e1/63/7c0e553ae0513ebf1858f08030158ff5998324013e0ba4c2e1c00b85df79/pip-21.2.3.tar.gz#sha256=91e66f2a2702e7d2dcc092ed8c5ebe923e69b9997ea28ba25823943bcd3bf820 (from https://pypi.org/simple/pip/) (requires-python:>=3.6), version: 21.2.3
  Found link https://files.pythonhosted.org/packages/ca/31/b88ef447d595963c01060998cb329251648acf4a067721b0452c45527eb8/pip-21.2.4-py3-none-any.whl#sha256=fa9ebb85d3fd607617c0c44aca302b1b45d87f9c2a1649b46c26167ca4296323 (from https://pypi.org/simple/pip/) (requires-python:>=3.6), version: 21.2.4
  Found link https://files.pythonhosted.org/packages/52/e1/06c018197d8151383f66ebf6979d951995cf495629fc54149491f5d157d0/pip-21.2.4.tar.gz#sha256=0eb8a1516c3d138ae8689c0c1a60fde7143310832f9dc77e11d8a4bc62de193b (from https://pypi.org/simple/pip/) (requires-python:>=3.6), version: 21.2.4
Skipping link: not a file: https://pypi.org/simple/pip/
Given no hashes to check 177 links for project 'pip': discarding no candidates
WARNING: You are using pip version 21.1.3; however, version 21.2.4 is available.
You should consider upgrading via the '/usr/local/Cellar/virt-manager/2.2.1_3/libexec/bin/python3.9 -m pip install --upgrade pip' command.
Removed build tracker: '/private/tmp/pip-req-tracker-61thydeq'

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/jeffreywildman/homebrew-virt-manager/issues
```

@jeffreywildman  