### PR TITLE
Possibly fix virt-viewer downoad error

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If `virt-manager` or its dependencies have been upgraded recently (`brew upgrade
 
 #### Why am I getting the error "No GSettings schemas are installed on the system"?
 
-You must make sure that  ``/usr/local/share`` is not missing from XDG_DATA_DIRS. If it is, add it to XDG_DATA_DIRS. You can make sure by running ``echo $XDG_DATA_DIRS`` .
+You must make sure that  ``/usr/local/share`` is not missing from XDG_DATA_DIRS. If it is, add it to XDG_DATA_DIRS. You can make sure by running ``echo $XDG_DATA_DIRS`` (better in a new bash, zsh etc. session since if you set that environment variable temporarily it would only fix the issue for that shell session). 
 
 [homebrew]: http://brew.sh/
 [virt-manager]: https://virt-manager.org/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ I've not yet tested `virt-manager` against any local URIs/hypervisors. If you ge
 
 If `virt-manager` or its dependencies have been upgraded recently (`brew upgrade`), it's possible that a reinstall may fix the issue (see [#39](https://github.com/jeffreywildman/homebrew-virt-manager/issues/39)).
 
+
+#### Why am I getting the error "No GSettings schemas are installed on the system"?
+
+You must make sure that  ``/usr/local/share`` is not missing from XDG_DATA_DIRS. If it is, add it to XDG_DATA_DIRS. You can make sure by running ``echo $XDG_DATA_DIRS`` .
+
 [homebrew]: http://brew.sh/
 [virt-manager]: https://virt-manager.org/
 [virt-viewer]: https://virt-manager.org/

--- a/virt-manager.rb
+++ b/virt-manager.rb
@@ -27,8 +27,8 @@ class VirtManager < Formula
   depends_on "vte3"
 
   resource "libvirt-python" do
-    url "https://libvirt.org/sources/python/libvirt-python-6.10.0.tar.gz"
-    sha256 "47a8e90d9f49bc0296d2817f6009e18dbb69844ce10b81c2a2672bccd6f49fd5"
+    url "https://libvirt.org/sources/python/libvirt-python-7.6.0.tar.gz"
+    sha256 "d8f9d4efdc79ad6b44bc43e49d6fa56d119895ba6c0bb000c6514ce84f19a13e"
   end
 
   resource "idna" do

--- a/virt-viewer.rb
+++ b/virt-viewer.rb
@@ -1,7 +1,7 @@
 class VirtViewer < Formula
   desc "App for virtualized guest interaction"
   homepage "https://virt-manager.org/"
-  url "https://virt-manager.org/download/sources/virt-viewer/virt-viewer-8.0.tar.gz"
+  url "https://releases.pagure.org/virt-viewer/virt-viewer-8.0.tar.gz"
   sha256 "dcf358ed5d7a4900215133135a6492c04311d84332816d930df9a89d6195b6ed"
 
   depends_on "intltool" => :build


### PR DESCRIPTION
Getting following error while installing virt-viewer: 
```
Error: virt-viewer: Failed to download resource "virt-viewer"
Download failed: https://virt-manager.org/download/sources/virt-viewer/virt-viewer-8.0.tar.gz
```
virt-viewer-8.0.tar.gz is moved to https://releases.pagure.org/virt-viewer/.

Updated the URL to match this.